### PR TITLE
Update max colors to remove greyscale colors without much contrast

### DIFF
--- a/style.go
+++ b/style.go
@@ -5,7 +5,7 @@ package termui
 // 0-255 = Xterm colors
 type Color int
 
-const MaxColor = 255
+const MaxColor = 232 // Only include colors that contrast well  
 const MinColor = 0
 
 // ColorClear clears the Fg or Bg color of a Style


### PR DESCRIPTION
This PR updates the MaxColor value to only include values up to 230. This is to prevent using colors for the line graph that are too difficult to see. 